### PR TITLE
Extend example package

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,7 @@
+^README\.md$
+^\.gitignore$
+^\.Rproj\.user$
+^\.Rhistory$
+^\.RData$
+^\.DS_Store$
+^vignettes/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,0 +1,11 @@
+Package: myrpackage
+Type: Package
+Title: A Minimal R Package
+Version: 0.0.0.9000
+Authors@R:
+    person(given = "Diogo", family = "Ribeiro", email = "dfr@esmad.ipp.pt", role = c("aut", "cre"), comment = c(ORCID = "0009-0001-2022-7072", affiliation = "ESMAD - Instituto Politécnico do Porto"))
+Description: A short description of what the package does.
+License: MIT + file LICENSE
+Encoding: UTF-8
+LazyData: true
+RoxygenNote: 7.3.0

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,0 +1,2 @@
+export(hello)
+export(goodbye)

--- a/R/goodbye.R
+++ b/R/goodbye.R
@@ -1,0 +1,9 @@
+#' Say Goodbye
+#'
+#' This function prints a friendly farewell.
+#'
+#' @return No return value, called for side effects.
+#' @export
+goodbye <- function() {
+  print("Goodbye, world!")
+}

--- a/R/hello.R
+++ b/R/hello.R
@@ -1,0 +1,9 @@
+#' Say Hello
+#'
+#' This function prints a friendly greeting.
+#'
+#' @return No return value, called for side effects.
+#' @export
+hello <- function() {
+  print("Hello, world!")
+}

--- a/README.md
+++ b/README.md
@@ -11,17 +11,22 @@ myrpackage/
 ├── DESCRIPTION               # Package metadata
 ├── NAMESPACE                # Generated from roxygen2 docs
 ├── R/
-│   └── hello.R              # Example R function with documentation
+│   ├── hello.R              # Example R function with documentation
+│   └── goodbye.R            # Another example function
 ├── man/
-│   └── hello.Rd             # Generated manual file
+│   ├── hello.Rd             # Generated manual file
+│   └── goodbye.Rd           # Manual for goodbye
 ├── tests/
 │   └── testthat/
-│       └── test-hello.R     # Unit test
+│       ├── test-hello.R     # Unit test
+│       └── test-goodbye.R   # Unit test
 │   └── testthat.R           # Testthat runner setup
 ├── vignettes/
 │   └── intro.Rmd            # Long-form documentation (optional)
 ├── .Rbuildignore            # Files ignored during build
 ├── .gitignore               # Git ignore rules
+├── inst/
+│   └── CITATION            # Citation information
 ├── LICENSE                  # Open-source license (MIT recommended)
 └── README.md                # Project overview and usage
 ```
@@ -59,9 +64,22 @@ hello <- function() {
   print("Hello, world!")
 }
 ```
-
 ---
 
+## 📄 R/goodbye.R
+
+```r
+#' Say Goodbye
+#'
+#' This function prints a friendly farewell.
+#'
+#' @return No return value, called for side effects.
+#' @export
+goodbye <- function() {
+  print("Goodbye, world!")
+}
+```
+---
 ## 🧪 tests/testthat/test-hello.R
 
 ```r
@@ -102,10 +120,16 @@ test_check("myrpackage")
 ```
 MIT License
 
-Copyright (c) 2025 Your Name
+Copyright (c) 2025 Diogo Ribeiro
 
 Permission is hereby granted, free of charge, to any person obtaining a copy...
 ```
+---
+
+## 📑 Citation
+
+To cite this package, run `citation("myrpackage")` in R. This will display the bibliographic information from `inst/CITATION`.
+
 
 ---
 
@@ -115,54 +139,3 @@ Permission is hereby granted, free of charge, to any person obtaining a copy...
 ---
 title: "Getting Started with myrpackage"
 output: rmarkdown::html_vignette
-vignette: >
-  %\VignetteIndexEntry{Getting Started}
-  %\VignetteEngine{knitr::rmarkdown}
-  %\VignetteEncoding{UTF-8}
----
-
-```{r setup, include = FALSE}
-library(myrpackage)
-````
-
-This is an introduction to using the package.
-
-````
-
----
-
-## 🚀 Development Workflow
-
-1. **Set up the package in RStudio or manually**:
-   ```r
-   usethis::create_package("myrpackage")
-   usethis::use_git()
-   usethis::use_mit_license()
-   usethis::use_roxygen_md()
-   usethis::use_testthat()
-   devtools::document()
-````
-
-2. **Check your package**:
-
-   ```r
-   devtools::check()
-   ```
-
-3. **Install locally**:
-
-   ```r
-   devtools::install()
-   ```
-
-4. **Submit to CRAN**:
-
-   ```r
-   devtools::release()
-   ```
-
----
-
-## ✅ Summary
-
-This scaffold provides everything needed to start building an R package with good development hygiene, testing, documentation, and CRAN readiness.

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,0 +1,16 @@
+citHeader("To cite myrpackage in publications use:")
+
+bibentry(
+  "Manual",
+  title = "myrpackage: A Minimal R Package",
+  author = person(given = "Diogo", family = "Ribeiro",
+                  email = "dfr@esmad.ipp.pt",
+                  role = c("aut", "cre"),
+                  comment = c(ORCID = "0009-0001-2022-7072",
+                              affiliation = "ESMAD - Instituto Politécnico do Porto")),
+  year = format(Sys.Date(), "%Y"),
+  note = "R package version 0.0.0.9000",
+  url = "https://github.com/DiogoRibeiro7/myrpackage"
+)
+
+citFooter("Please cite this package when using it.")

--- a/man/goodbye.Rd
+++ b/man/goodbye.Rd
@@ -1,0 +1,6 @@
+\name{goodbye}
+\alias{goodbye}
+\title{Say Goodbye}
+\usage{goodbye()}
+\description{This function prints a friendly farewell.}
+\examples{goodbye()}

--- a/man/hello.Rd
+++ b/man/hello.Rd
@@ -1,0 +1,6 @@
+\name{hello}
+\alias{hello}
+\title{Say Hello}
+\usage{hello()}
+\description{This function prints a friendly greeting.}
+\examples{hello()}

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(myrpackage)
+
+test_check("myrpackage")

--- a/tests/testthat/test-goodbye.R
+++ b/tests/testthat/test-goodbye.R
@@ -1,0 +1,3 @@
+test_that("goodbye() prints correctly", {
+  expect_output(goodbye(), "Goodbye, world!")
+})

--- a/tests/testthat/test-hello.R
+++ b/tests/testthat/test-hello.R
@@ -1,0 +1,3 @@
+test_that("hello() prints correctly", {
+  expect_output(hello(), "Hello, world!")
+})

--- a/vignettes/intro.Rmd
+++ b/vignettes/intro.Rmd
@@ -1,0 +1,14 @@
+---
+title: "Getting Started with myrpackage"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Getting Started}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include = FALSE}
+library(myrpackage)
+```
+
+This is an introduction to using the package.


### PR DESCRIPTION
## Summary
- add README section on citing the package
- introduce `goodbye()` helper with docs and tests

## Testing
- `Rscript -e "source('R/hello.R'); source('R/goodbye.R'); library(testthat); testthat::test_dir('tests/testthat')" | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687b72ac539c8325a3b284e3aa70e027